### PR TITLE
Fix chart truncation in Firefox

### DIFF
--- a/src/app/box-plot/box-plot.component.scss
+++ b/src/app/box-plot/box-plot.component.scss
@@ -1,0 +1,4 @@
+highcharts-chart {
+  display: block;
+  max-width: 600px;
+}


### PR DESCRIPTION
### Proposal
Provide a short description of the change you are proposing and the reasons for it.

This change would fix the truncated chart bug in Firefox. Also, it would limit the `max-width` of `highcharts-chart` component to a `600px` and let it shrink on smaller screens.

### Related
Provide links to any associated pull requests or issues. You can use `#123` to link to a PR or issue in this repository, or `user/repo#123` to link to other repositories.

If merged this would fix issue #5. 

### Checklist

- [x] I have read the [code of conduct] and [contributing guide]
- [x] I have made this pull request to the `main` branch
- [x] I have run all of the automated validation using `npm run ship`
- [x] I have added myself to the `"contributors"` list in the `package.json` (or do not want to) (I think it's too small of a change for my name to be there)

[code of conduct]: CODE_OF_CONDUCT.md
[contributing guide]: CONTRIBUTING.md
