### PR TITLE
Restore Codacy coverage reporting

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,10 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run test:cover
+      - name: Send coverage to Codacy
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l TypeScript -r ./coverage/lcov.info
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thank you for contributing! To help the review process, please provide the following:

### Proposal
Send coverage reports to Codacy during the build.

### Related
N/A

### Checklist

- [x] I have read the [code of conduct] and [contributing guide]
- [x] I have made this pull request to the `main` branch
- [ ] I have run all of the automated validation using `npm run ship`
- [ ] I have added myself to the `"contributors"` list in the `package.json` (or do not want to)

[code of conduct]: CODE_OF_CONDUCT.md
[contributing guide]: CONTRIBUTING.md
